### PR TITLE
Added support for data URI

### DIFF
--- a/textile/core.py
+++ b/textile/core.py
@@ -90,7 +90,7 @@ class Textile(object):
 
     restricted_url_schemes = ('http', 'https', 'ftp', 'mailto')
     unrestricted_url_schemes = restricted_url_schemes + ('file', 'tel',
-            'callto', 'sftp')
+            'callto', 'sftp', 'data')
 
     btag = ('bq', 'bc', 'notextile', 'pre', 'h[1-6]', 'fn\d+', 'p', '###')
     btag_lite = ('bq', 'bc', 'p')


### PR DESCRIPTION
A image link using the [data URI](https://en.wikipedia.org/wiki/Data_URI_scheme) scheme does not convert properly currently.

```Python
>>> image = r'!data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==!'
>>> textile.Textile().image(image)
<img alt="" src="#" />
```
The merge request adds 'data' to the unrestricted_url_schemes variable.
```Python
>>> image = r'!data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==!'
>>> textile.Textile().image(image)
<img alt="" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" />
```