### PR TITLE
Fix for paragraph multiline, only last paragraph is rendered correctly

### DIFF
--- a/tests/test_github_issues.py
+++ b/tests/test_github_issues.py
@@ -290,9 +290,49 @@ Here is some output!!! "Some" CAPS'''
 
 Back to 10-4 CAPS </code></pre>
 
-<p>Some multiline Paragragh
+<p>Some multiline Paragragh</p>
 
-Here is some output!!! &#8220;Some&#8221; <span class="caps">CAPS</span></p>'''
+<p>Here is some output!!! &#8220;Some&#8221; <span class="caps">CAPS</span></p>'''
+    t = textile.Textile()
+    result = t.parse(input)
+    assert result == expect
+
+def test_issue_58():
+    input = '''p.. First one 'is'
+
+ESCAPED "bad"
+
+p.. Second one 'is'
+
+
+
+ESCAPED "bad"
+
+p.. Third one 'is'
+
+ESCAPED "bad"
+
+p.. Last one 'is'
+
+ESCAPED "good" test'''
+
+    expect = '''<p>First one &#8216;is&#8217;</p>
+
+<p><span class="caps">ESCAPED</span> &#8220;bad&#8221;</p>
+
+<p>Second one &#8216;is&#8217;</p>
+
+
+
+<p><span class="caps">ESCAPED</span> &#8220;bad&#8221;</p>
+
+<p>Third one &#8216;is&#8217;</p>
+
+<p><span class="caps">ESCAPED</span> &#8220;bad&#8221;</p>
+
+<p>Last one &#8216;is&#8217;</p>
+
+<p><span class="caps">ESCAPED</span> &#8220;good&#8221; test</p>'''
     t = textile.Textile()
     result = t.parse(input)
     assert result == expect


### PR DESCRIPTION
Hi,

Me agian.
There is another error which happens if you use multiple line blocks on paragraph.
If the input is:

```
p.. First one 'is'

ESCAPED "bad"

p.. Second one 'is'

ESCAPED "bad"

p.. Third one 'is'

ESCAPED "bad"

p.. Last one 'is'

ESCAPED "good"
```

The textile output is:

```
<p>First one &amp;#8216;is&amp;#8217;

&lt;span class=&quot;caps&quot;&gt;ESCAPED&lt;/span&gt; &amp;#8220;bad&amp;#8221;</p>

<p>Second one &amp;#8216;is&amp;#8217;

&lt;span class=&quot;caps&quot;&gt;ESCAPED&lt;/span&gt; &amp;#8220;bad&amp;#8221;</p>

<p>Third one &amp;#8216;is&amp;#8217;

&lt;span class=&quot;caps&quot;&gt;ESCAPED&lt;/span&gt; &amp;#8220;bad&amp;#8221;</p>

<p>Last one &#8216;is&#8217;

<span class="caps">ESCAPED</span> &#8220;good&#8221;</p>
```

Here we can see that only the last ```p..``` is escaped good.
Other (previous) paragraphs are double escaped:

```
&amp;#8216; (Double escaped, should be &#8216;)
&lt;span class=&quot;caps&quot;&gt;...&lt;/span&gt; (Double escaped, should be <span class="caps">ESCAPED</span>
```

Added test and fix.
The fix works as follows:

In utils.py
Added boolean ampersand.
If ampersand is True, add ampersand tuple. ```a = a + (('&', '&amp;'),)```

In core.py
on line 461:
Ampersand is set to false so that ampersand are not escaped

On line 508-509:
If the block tag is ```p``` then the ```graf()``` output is shelved (This fixes double escaping on the <span class='caps>...</span>'
