### PR TITLE
Forgot to set multiline_para to False

### DIFF
--- a/tests/test_github_issues.py
+++ b/tests/test_github_issues.py
@@ -336,3 +336,67 @@ ESCAPED "good" test'''
     t = textile.Textile()
     result = t.parse(input)
     assert result == expect
+
+def test_issue_59():
+    input = '''p.. First one 'is'
+
+ESCAPED "bad"
+
+bc.. {
+ First code BLOCK
+
+ {"JSON":'value'}
+}
+
+p.. Second one 'is'
+
+
+
+ESCAPED "bad"
+
+p.. Third one 'is'
+
+ESCAPED "bad"
+
+bc.. {
+ Last code BLOCK
+
+ {"JSON":'value'}
+}
+
+p.. Last one 'is'
+
+ESCAPED "good" test'''
+
+    expect = '''<p>First one &#8216;is&#8217;</p>
+
+<p><span class="caps">ESCAPED</span> &#8220;bad&#8221;</p>
+
+<pre><code>{
+ First code BLOCK
+
+ {&quot;JSON&quot;:&#39;value&#39;}
+}</code></pre>
+
+<p>Second one &#8216;is&#8217;</p>
+
+
+
+<p><span class="caps">ESCAPED</span> &#8220;bad&#8221;</p>
+
+<p>Third one &#8216;is&#8217;</p>
+
+<p><span class="caps">ESCAPED</span> &#8220;bad&#8221;</p>
+
+<pre><code>{
+ Last code BLOCK
+
+ {&quot;JSON&quot;:&#39;value&#39;}
+}</code></pre>
+
+<p>Last one &#8216;is&#8217;</p>
+
+<p><span class="caps">ESCAPED</span> &#8220;good&#8221; test</p>'''
+    t = textile.Textile()
+    result = t.parse(input)
+    assert result == expect

--- a/textile/core.py
+++ b/textile/core.py
@@ -536,6 +536,9 @@ class Textile(object):
             else:
                 line = self.doPBr(line)
 
+            if not block.tag == 'p':
+                multiline_para = False
+
             line = line.replace('<br>', '<br />')
 
             # if we're in an extended block, and we haven't specified a new


### PR DESCRIPTION
Hey @ikirudennis,

I am sorry for the inconvenience yet again. The multiline_para boolean that I added before needs to be closed if  ```block.tag == 'p'``` is not true. Because we want to render multiline codeblock after a multiline p..

I added a test that has multiple multiline codeblocks and multiple multiline paragraphs and checked that the output is verified against txstyle.org/textile. 

Added a small piece of code that sets the boolean to False if block.tag is nog p. because we only need it to work for multiline, it does not matter for single p.

Thanks a bunch! 