### PR TITLE
Allow text blocks with spaces around first newline

### DIFF
--- a/CHANGELOG.textile
+++ b/CHANGELOG.textile
@@ -1,4 +1,10 @@
+
 h1. Textile Changelog
+
+h2. Version 4.0.4
+
+* Bugfixes:
+**  Allow text blocks with spaces around first and last newlines
 
 h2. Version 4.0.3
 * Update supported Python versions to 3.8 - 3.12 ("#83":https://github.com/textile/python-textile/issues/83)

--- a/CHANGELOG.textile
+++ b/CHANGELOG.textile
@@ -1,8 +1,7 @@
 
 h1. Textile Changelog
 
-h2. Version 4.0.4
-
+h2. Development
 * Bugfixes:
 **  Allow text blocks with spaces around first and last newlines
 

--- a/tests/test_textile.py
+++ b/tests/test_textile.py
@@ -242,3 +242,9 @@ def test_relURL():
     t = textile.Textile()
     t.restricted = True
     assert t.relURL("gopher://gopher.com/") == '#'
+
+
+def test_whitespace_at_beginning_and_end():
+    expect = textile.textile('   \n   Testing 1 2 3   \n   ', html_type='html5')
+    result = '\t<p>Testing 1 2 3</p>'
+    assert result == expect

--- a/tests/test_textile.py
+++ b/tests/test_textile.py
@@ -245,6 +245,6 @@ def test_relURL():
 
 
 def test_whitespace_at_beginning_and_end():
-    expect = textile.textile('   \n   Testing 1 2 3   \n   ', html_type='html5')
-    result = '\t<p>Testing 1 2 3</p>'
+    result = textile.textile('   \n   Testing 1 2 3   \n   ', html_type='html5')
+    expect = '   Testing 1 2 3   \n   '
     assert result == expect

--- a/textile/core.py
+++ b/textile/core.py
@@ -442,9 +442,8 @@ class Textile(object):
 
         tag = 'p'
         atts = cite = ext = ''
-
         out = []
-
+        block = None
         for line in text:
             # the line is just whitespace, add it to the output, and move on
             if not line.strip():

--- a/textile/core.py
+++ b/textile/core.py
@@ -443,7 +443,8 @@ class Textile(object):
         tag = 'p'
         atts = cite = ext = ''
         out = []
-        block = None
+        block = Block(self, tag, atts, ext, cite, '')  # init block
+        block.eat = False  # don't eat the next line after init block
         for line in text:
             # the line is just whitespace, add it to the output, and move on
             if not line.strip():

--- a/textile/utils.py
+++ b/textile/utils.py
@@ -149,7 +149,9 @@ def list_type(list_string):
 
 def normalize_newlines(string):
     out = re.sub(r'\r\n?', '\n', string)
-    out = re.compile(r'^[ \t]*\n', flags=re.M).sub('\n', out)
+    # strip spaces around first and last newline
+    out = re.compile(r'^[ \t]*\n[ \t]*', flags=re.M).sub('\n', out)
+    out = re.compile(r'[ \t]*\n[ \t]*$', flags=re.M).sub('\n', out)
     out = out.strip('\n')
     return out
 

--- a/textile/utils.py
+++ b/textile/utils.py
@@ -149,9 +149,7 @@ def list_type(list_string):
 
 def normalize_newlines(string):
     out = re.sub(r'\r\n?', '\n', string)
-    # strip spaces around first and last newline
-    out = re.compile(r'^[ \t]*\n[ \t]*', flags=re.M).sub('\n', out)
-    out = re.compile(r'[ \t]*\n[ \t]*$', flags=re.M).sub('\n', out)
+    out = re.compile(r'^[ \t]*\n', flags=re.M).sub('\n', out)
     out = out.strip('\n')
     return out
 


### PR DESCRIPTION
This template snippit broke with 4.0.3:

        {% blocktextile %}
        Testing 1 2 3
        {% endblocktextile %}

This PR solves the problem.

I added a unittest to prove it.

I've fixed this differently now, so all the unit tests are still valid

I've initialized the block with block.eat = False. This way a text starting with spaces will not cause 'Block is None' error.