### PR TITLE
Don't crash on a link URL ending in '>'

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -69,3 +69,16 @@ def test_quotes_in_link_text():
     result = t.parse(test)
     expect = '\t<p><a href="url">&#8220;this is a quote in link text&#8221;</a></p>'
     assert result == expect
+
+
+def test_link_url_ending_in_angle_bracket():
+    """A link whose URL ends in '>' with no closing tag used to raise a raw
+    AttributeError; the '>' should be pushed out of the URL like other
+    trailing punctuation."""
+    t = Textile()
+    assert t.parse('"a":b>') == '\t<p><a href="b">a</a>&gt;</p>'
+    assert t.parse('"x":http://x.com/>') == (
+        '\t<p><a href="http://x.com/">x</a>&gt;</p>')
+    # A genuine trailing closing tag is still absorbed as before.
+    assert t.parse('"y":http://x.com/</a') == (
+        '\t<p><a href="http://x.com/%3C/a">y</a></p>')

--- a/textile/core.py
+++ b/textile/core.py
@@ -888,6 +888,9 @@ class Textile(object):
             urlLeft = ''.join(url_chars)
 
             m = re.search(r'(?P<url_chars>.*)(?P<tag><\/[a-z]+)$', urlLeft)
+            if m is None:
+                # Lone trailing '>' (no closing tag): pop it out the back.
+                return '{0}{1}'.format(c, pop), True, url_chars, counts, pre
             url_chars = m.group('url_chars')
             pop = '{0}{1}{2}'.format(m.group('tag'), c, pop)
             popped = True


### PR DESCRIPTION
A Textile link whose URL ends in a bare `>` with no closing tag crashed with `AttributeError: 'NoneType' object has no attribute 'group'`. In `_rightanglebracket`, the regex that strips a trailing `</tag>` returns `None` for a lone `>`, and `m.group(...)` is called unconditionally.

The sibling `_endchar` handler already degrades trailing punctuation by popping it out the back of the URL; this does the same for a lone `>`.

```python
import textile
textile.textile('"a":b>')  # was: AttributeError; now: <p><a href="b">a</a>&gt;</p>
```