### PR TITLE
Don't crash on Textile links to IPv6 literal URLs

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -72,10 +72,10 @@ def test_quotes_in_link_text():
 
 
 def test_ipv6_literal_link_keeps_single_closing_bracket():
-    import textile
-    out = textile.textile('"host":http://[2001:db8::1]/')
-    assert out == '\t<p><a href="http://[2001:db8::1]/">host</a></p>'
-    out = textile.textile('"loopback":http://[::1]/')
-    assert out == '\t<p><a href="http://[::1]/">loopback</a></p>'
-    out = textile.textile('"port":http://[::1]:8080/')
-    assert out == '\t<p><a href="http://[::1]:8080/">port</a></p>'
+    t = Textile()
+    assert t.parse('"host":http://[2001:db8::1]/') == (
+        '\t<p><a href="http://[2001:db8::1]/">host</a></p>')
+    assert t.parse('"loopback":http://[::1]/') == (
+        '\t<p><a href="http://[::1]/">loopback</a></p>')
+    assert t.parse('"port":http://[::1]:8080/') == (
+        '\t<p><a href="http://[::1]:8080/">port</a></p>')

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -79,3 +79,10 @@ def test_ipv6_literal_link_keeps_single_closing_bracket():
         '\t<p><a href="http://[::1]/">loopback</a></p>')
     assert t.parse('"port":http://[::1]:8080/') == (
         '\t<p><a href="http://[::1]:8080/">port</a></p>')
+
+
+def test_unmatched_bracket_before_query_still_pops():
+    t = Textile()
+    # Master pops trailing after an unmatched ]; IPv6 reattach must not change that.
+    assert t.parse('"t":http://example.com/x]?q=1') == (
+        '\t<p><a href="http://example.com/x">t</a>?q=1</p>')

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -69,3 +69,13 @@ def test_quotes_in_link_text():
     result = t.parse(test)
     expect = '\t<p><a href="url">&#8220;this is a quote in link text&#8221;</a></p>'
     assert result == expect
+
+
+def test_ipv6_literal_link_keeps_single_closing_bracket():
+    import textile
+    out = textile.textile('"host":http://[2001:db8::1]/')
+    assert out == '\t<p><a href="http://[2001:db8::1]/">host</a></p>'
+    out = textile.textile('"loopback":http://[::1]/')
+    assert out == '\t<p><a href="http://[::1]/">loopback</a></p>'
+    out = textile.textile('"port":http://[::1]:8080/')
+    assert out == '\t<p><a href="http://[::1]:8080/">port</a></p>'

--- a/textile/core.py
+++ b/textile/core.py
@@ -864,7 +864,12 @@ class Textile(object):
         if (counts[']']):
             m = re.search(r'(?P<url>^.*\])(?!=)(?P<end>.*?)$', url, flags=re.U)
             url = m.group('url')
-            tight = '{0}{1}'.format(m.group('end'), tight)
+            end = m.group('end')
+            # Keep port/path/query/fragment after a bracketed IPv6 (or similar) ].
+            if end.startswith((':', '/', '?', '#')):
+                url = '{0}{1}'.format(url, end)
+                end = ''
+            tight = '{0}{1}'.format(end, tight)
 
         # Now we have the array of all the multi-byte chars in the url we will
         # parse the  uri backwards and pop off  any chars that don't belong
@@ -901,8 +906,8 @@ class Textile(object):
             counts['['] = counts['['] or url.count('[')
 
             if counts['['] == counts[']']:
-                # It is balanced, so keep it
-                url_chars.append(c)
+                # Balanced (e.g. IPv6 netloc); char already in url_chars.
+                pass
             else:
                 # In the case of un-matched closing square brackets we just eat
                 # it
@@ -1001,13 +1006,25 @@ class Textile(object):
         parsed = urlsplit(url)
 
         if parsed.netloc:
-            # divide the netloc further
-            netloc_pattern = re.compile(r"""
-                (?:(?P<user>[^:@]+)(?::(?P<password>[^:@]+))?@)?
-                (?P<host>[^:]+)
-                (?::(?P<port>[0-9]+))?
-            """, re.X | re.U)
-            netloc_parsed = netloc_pattern.match(parsed.netloc).groupdict()
+            # Bracketed IPv6 netlocs contain colons; keep [addr] intact.
+            ipv6 = re.match(
+                r'^(?P<host>\[[^\]]+\])(?::(?P<port>[0-9]+))?$',
+                parsed.netloc,
+            )
+            if ipv6:
+                netloc_parsed = {
+                    'user': '',
+                    'password': '',
+                    'host': ipv6.group('host'),
+                    'port': ipv6.group('port') or '',
+                }
+            else:
+                netloc_pattern = re.compile(r"""
+                    (?:(?P<user>[^:@]+)(?::(?P<password>[^:@]+))?@)?
+                    (?P<host>[^:]+)
+                    (?::(?P<port>[0-9]+))?
+                """, re.X | re.U)
+                netloc_parsed = netloc_pattern.match(parsed.netloc).groupdict()
         else:
             netloc_parsed = {'user': '', 'password': '', 'host': '', 'port': ''}
 

--- a/textile/core.py
+++ b/textile/core.py
@@ -905,12 +905,8 @@ class Textile(object):
             # If counts['['] is None, count the occurrences of '['
             counts['['] = counts['['] or url.count('[')
 
-            if counts['['] == counts[']']:
-                # Balanced (e.g. IPv6 netloc); char already in url_chars.
-                pass
-            else:
-                # In the case of un-matched closing square brackets we just eat
-                # it
+            if counts['['] != counts[']']:
+                # Unmatched closing bracket: spit it out of the URL.
                 popped = True
                 url_chars.pop()
                 counts[']'] = counts[']'] - 1

--- a/textile/core.py
+++ b/textile/core.py
@@ -865,8 +865,9 @@ class Textile(object):
             m = re.search(r'(?P<url>^.*\])(?!=)(?P<end>.*?)$', url, flags=re.U)
             url = m.group('url')
             end = m.group('end')
-            # Keep port/path/query/fragment after a bracketed IPv6 (or similar) ].
-            if end.startswith((':', '/', '?', '#')):
+            # Reattach URL continuation only when ] is balanced (IPv6 netloc).
+            if (end.startswith((':', '/', '?', '#'))
+                    and url.count('[') == url.count(']')):
                 url = '{0}{1}'.format(url, end)
                 end = ''
             tight = '{0}{1}'.format(end, tight)


### PR DESCRIPTION
## Summary

Textile links to IPv6 literal URLs (`http://[2001:db8::1]/`) raised `ValueError: Invalid IPv6 URL` from `urlsplit`.

Keep bracketed IPv6 netlocs intact when building the href so the link renders.

## Test plan

- `pytest` (suite green locally)